### PR TITLE
default the defaults to 'default'

### DIFF
--- a/base/params.yml
+++ b/base/params.yml
@@ -5,9 +5,9 @@ params:
   server_instances: 3
   resolvconf_override: true
 
-  server_network:   servers
-  server_disk_type: server
-  server_vm_type:   server
+  server_network:   default
+  server_disk_type: default
+  server_vm_type:   default
 
   availability_zones: [z1, z2, z3]
 

--- a/subkits/nomad/params.yml
+++ b/subkits/nomad/params.yml
@@ -4,8 +4,8 @@ params:
 
   nomad_vault_role: nomad-cluster
 
-  node_network: nodes
-  node_disk_type: node
-  node_vm_type: node
+  node_network:   default
+  node_disk_type: default
+  node_vm_type:   default
   node_vm_extensions: []
   node_instances: 3


### PR DESCRIPTION
In bosh-deployment cloud-config.yml there are defaults of 'default'
for vm_types, disk_types, and networks.

e.g. https://github.com/cloudfoundry/bosh-deployment/blob/master/aws/cloud-config.yml